### PR TITLE
refactor(#41): android plugin initialization

### DIFF
--- a/src/android-utils.ts
+++ b/src/android-utils.ts
@@ -134,10 +134,13 @@ import com.facebook.react.uimanager.ViewManager
 import com.mrousavy.camera.frameprocessor.FrameProcessorPluginRegistry
 ${isApplicationPackage ? '' : `import ${packageName}.${pluginName.toLowerCase()}.${pluginName}Plugin\n`}
 class ${pluginName}PluginPackage : ReactPackage {
-  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
+  init {
     FrameProcessorPluginRegistry.addFrameProcessorPlugin("${methodName}") { options ->
       ${pluginName}Plugin()
     }
+  }
+
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> {
     return emptyList()
   }
 
@@ -163,10 +166,16 @@ import java.util.Collections;
 import java.util.List;
 
 public class ${pluginName}PluginPackage implements ReactPackage {
+  public ${pluginName}PluginPackage() {
+    FrameProcessorPluginRegistry.addFrameProcessorPlugin(
+            "${methodName}",
+            options -> new ${pluginName}Plugin()
+    );
+  }
+
   @NonNull
   @Override
   public List<NativeModule> createNativeModules(@NonNull ReactApplicationContext reactContext) {
-    FrameProcessorPluginRegistry.addFrameProcessorPlugin("${methodName}", options -> new ${pluginName}Plugin());
     return Collections.emptyList();
   }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -15,7 +15,10 @@ const plugin = VisionCameraProxy.getFrameProcessorPlugin('${methodName}')
 
 export function ${methodName}(frame: Frame) {
   'worklet'
-  return plugin?.call(frame)
+  if (plugin == null) {
+    throw new Error("Failed to load Frame Processor Plugin!")
+  }
+  return plugin.call(frame)
 }`)}
 `)}`.trim());
   console.log('\n');


### PR DESCRIPTION
This pull request resolves #41 

**Description**

<!-- Describe, what this pull request is solving. -->

Move android FP plugin registration to constructor / init block rather then `createNativeModules` method
