### PR TITLE
fix(#48): extracting package name regex

### DIFF
--- a/src/android-utils.ts
+++ b/src/android-utils.ts
@@ -16,7 +16,7 @@ const ANDROID_GLOB_OPTIONS = {
   nodir: false,
 };
 
-const NAMESPACE_VALUE_REGEX = /namespace (= ){0,1}"([A-Za-z]{1}[A-Za-z\d_]*\.)+[A-Za-z][A-Za-z\d_]*"/;
+const NAMESPACE_VALUE_REGEX = /namespace (= ){0,1}("|')([A-Za-z]{1}[A-Za-z\d_]*\.)+[A-Za-z][A-Za-z\d_]*("|')/;
 const PACKAGE_NAME_REGEX = /([A-Za-z]{1}[A-Za-z\d_]*\.)+[A-Za-z][A-Za-z\d_]*/;
 const PACKAGE_ATTRIBUTE_REGEX = /package="(.+?)"/;
 
@@ -67,6 +67,38 @@ export const extractPackageName = (workingDir: string, manifestPath: string) => 
  }
 
  return packageNameMatchArray[1] as string;
+};
+
+export const displayExtractPackageNameErrorMessage = () => {
+  console.error(kleur.red(`
+Cannot extract package from gradle scripts or manifest
+
+Make sure either:
+1. your application/library's "build.gradle" file has "namespace" value assigned e.g.
+
+android {
+  ndkVersion rootProject.ext.ndkVersion
+
+  compileSdkVersion rootProject.ext.compileSdkVersion
+
+  // in Groovy build.gradle you can use single or double quoted strings
+  namespace "com.myawesomeapp" // <--- add this
+  // namespace 'com.myawesomeapp' // <--- or this
+
+  // in Kotlin build.gradle.kts you must use double quotes string and "=" char
+  // namespace = "com.myawesomeapp" // <--- add this
+
+  // ...
+}
+
+2. your application/library's "AndroidManifest.xml" has a package attribute assigned e.g.
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.myawesomeapp"> // <--- add this
+
+
+</manifest>
+`));
 };
 
 /**

--- a/src/android.ts
+++ b/src/android.ts
@@ -9,6 +9,7 @@ import {
   createAndroidPluginDirectory,
   createPluginFile,
   createPluginPackageFile,
+  displayExtractPackageNameErrorMessage,
   displayFinishStepsForAndroidApplicationPlugin,
   displayFinishStepsForAndroidLibraryPlugin,
   extractPackageName,
@@ -93,10 +94,11 @@ export async function androidCommandHandler(argv: Arguments<unknown>) {
   spinner.text = 'Extracting android package name';
   spinner.start();
   
-  const packageName = extractPackageName(process.cwd(), manifestPath);
+  const packageName = extractPackageName(path.resolve(manifestPath, '..', '..'), manifestPath);
 
   if (!packageName) {
-    console.error(kleur.red('\nCannot extract package from gradle scripts or manifest\n'));
+    spinner.fail();
+    displayExtractPackageNameErrorMessage();
     return;
   }
 
@@ -108,6 +110,7 @@ export async function androidCommandHandler(argv: Arguments<unknown>) {
   const sourceDir = getSourceSetDirectory(manifestPath, packageName);
 
   if (!sourceDir) {
+    spinner.fail();
     console.error(kleur.red(`\nCannot find main source set at ${sourceDir}\n`));
     return;
   }


### PR DESCRIPTION
This pull request resolves #48 

**Description**

<!-- Describe, what this pull request is solving. -->

Fix extracting package name regex - this will make following namespace values discoverable

build.gradle (Groovy)

```
namespace 'com.myawesomeapp'
namespace "com.myawesomeapp"
```

build.gradle.kts (Kotlin script)

```
namespace = "com.myawesomeapp"
```

Also error message is improved to make it easier for devs to fix error
